### PR TITLE
Some additions to set and map

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -50,6 +50,16 @@ where
     last: CopyCell<Option<&'arena MapNode<'arena, K, V>>>,
 }
 
+impl<'arena, K, V> Default for Map<'arena, K, V>
+where
+    K: 'arena,
+    V: 'arena + Copy,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'arena, K, V> Map<'arena, K, V>
 where
     K: 'arena,

--- a/src/map.rs
+++ b/src/map.rs
@@ -148,6 +148,14 @@ where
 
     /// Returns the value corresponding to the key.
     #[inline]
+    pub fn get_key(&self, key: K) -> Option<&K> {
+        let hash = Self::hash_key(&key);
+
+        self.find_slot(key, hash).get().map(|node| &node.key)
+    }
+
+    /// Returns the value corresponding to the key.
+    #[inline]
     pub fn get(&self, key: K) -> Option<V> {
         let hash = Self::hash_key(&key);
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -55,6 +55,12 @@ where
         self.map.insert(arena, item, ());
     }
 
+    /// Gets a reference to the existing value in the set, if it exists
+    #[inline]
+    pub fn get(&self, key: I) -> Option<&I> {
+        self.map.get_key(key)
+    }
+
     /// Returns `true` if the set contains a value.
     #[inline]
     pub fn contains(&self, item: I) -> bool {

--- a/src/set.rs
+++ b/src/set.rs
@@ -12,6 +12,15 @@ pub struct Set<'arena, I: 'arena> {
     map: Map<'arena, I, ()>,
 }
 
+impl<'arena, I> Default for Set<'arena, I>
+where
+    I: 'arena,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'arena, I> Set<'arena, I>
 where
     I: 'arena,


### PR DESCRIPTION
This PR allows one to get a reference to a map's key (and by extension, a set's value). This is useful for using sets to implement string interning.