### PR TITLE
Use a union to avoid UB with uninitialized &mut T

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toolshed"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Arena allocator and a handful of useful data structures"


### PR DESCRIPTION
The soundness rules of `unsafe` code are not completely settled in the language, but in some proposals creating `&mut T` with an uninitialized `T` value is Undefined Behavior even if nothing reads from that reference.

In a union with a zero-size variant however, being uninitialized is a valid state since the storage for that variant is entirely padding.

Bumping the version number because of the new `T: Copy` bound on `Uninitialized`, which is require because unions with non-Copy fields https://github.com/rust-lang/rust/issues/32836 (or the `MaybeUninit` union itself https://github.com/rust-lang/rust/issues/53491) are not stable in the language yet.