### PR TITLE
Comments on, and hopefully an increase of `CopyCell` soundness

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -33,17 +33,6 @@ impl<T> CopyCell<T> {
 }
 
 impl<T: Copy> CopyCell<T> {
-    #[inline]
-    fn mut_ptr(&self) -> *mut T {
-        // We can just cast the pointer from `CopyCell<T>` to `T` because of
-        // #[repr(transparent)]
-        //
-        // This behavior is copied over from the std implementation of
-        // the `UnsafeCell`, and it's the best we can do right now in terms
-        // of soundness till we get a stable `UnsafeCell` that implements `Copy`.
-        self as *const CopyCell<T> as *const T as *mut T
-    }
-
     /// Returns a copy of the contained value.
     #[inline]
     pub fn get(&self) -> T {
@@ -55,9 +44,11 @@ impl<T: Copy> CopyCell<T> {
     /// This call borrows `CopyCell` mutably, which gives us a compile time
     /// memory safety guarantee.
     #[inline]
-    pub fn get_mut(&mut self) -> &mut T {
+    pub fn get_mut<'a>(&'a mut self) -> &'a mut T {
+        // We can just cast the pointer from `CopyCell<T>` to `T` because of
+        // #[repr(transparent)]
         unsafe {
-            &mut *self.mut_ptr()
+            &mut *(self as *mut CopyCell<T> as *mut T)
         }
     }
 
@@ -69,7 +60,14 @@ impl<T: Copy> CopyCell<T> {
         // Regular write produces abnormal behavior when running tests in
         // `--release` mode. Reordering writes when the compiler assumes
         // things are immutable is dangerous.
-        unsafe { write_volatile(self.mut_ptr(), value) };
+        //
+        // We can just cast the pointer from `CopyCell<T>` to `T` because of
+        // #[repr(transparent)]
+        //
+        // This behavior is copied over from the std implementation of
+        // the `UnsafeCell`, and it's the best we can do right now in terms
+        // of soundness till we get a stable `UnsafeCell` that implements `Copy`.
+        unsafe { write_volatile(self as *const CopyCell<T> as *const T as *mut T, value) };
     }
 }
 


### PR DESCRIPTION
This makes `CopyCell` behave more alike `UnsafeCell` internally. It doesn't solve #5, but it at least addresses the concerns.