### PR TITLE
Edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "toolshed"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["maciejhirsz <maciej.hirsz@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Arena allocator and a handful of useful data structures"
 repository = "https://github.com/ratel-rust/toolshed"
 documentation = "https://docs.rs/toolshed/"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
-fxhash = "0.2"
+rustc-hash = "1.0"
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/benches/bloomset.rs
+++ b/benches/bloomset.rs
@@ -1,13 +1,11 @@
 #![feature(test)]
 extern crate test;
-extern crate fxhash;
-extern crate toolshed;
 
 use toolshed::set::{BloomSet, Set};
 use toolshed::Arena;
 use test::{Bencher, black_box};
 use std::collections::HashSet;
-use fxhash::FxHashSet;
+use rustc_hash::FxHashSet;
 
 static WORDS: &[&str] = &[
     "ARENA_BLOCK", "Arena", "Cell", "Self", "String", "T", "Vec", "_unchecked", "a",

--- a/benches/list.rs
+++ b/benches/list.rs
@@ -1,7 +1,5 @@
 #![feature(test)]
 extern crate test;
-extern crate fxhash;
-extern crate toolshed;
 
 use toolshed::list::ListBuilder;
 use toolshed::Arena;

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -23,7 +23,7 @@ pub struct Arena {
 }
 
 /// A pointer to an uninitialized region of memory.
-pub struct Uninitialized<'arena, T: Copy + 'arena> {
+pub struct Uninitialized<'arena, T: Copy> {
     pointer: &'arena mut MaybeUninit<T>,
 }
 
@@ -33,7 +33,7 @@ union MaybeUninit<T: Copy> {
     _uninit: (),
 }
 
-impl<'arena, T: Copy + 'arena> Uninitialized<'arena, T> {
+impl<'arena, T: Copy> Uninitialized<'arena, T> {
     /// Initialize the memory at the pointer with a given value.
     #[inline]
     pub fn init(self, value: T) -> &'arena mut T {
@@ -69,7 +69,7 @@ impl<'arena, T: Copy + 'arena> Uninitialized<'arena, T> {
     }
 }
 
-impl<'arena, T: Copy + 'arena> From<&'arena mut T> for Uninitialized<'arena, T> {
+impl<'arena, T: Copy> From<&'arena mut T> for Uninitialized<'arena, T> {
     #[inline]
     fn from(pointer: &'arena mut T) -> Self {
         unsafe { Self::from_raw(pointer) }
@@ -102,7 +102,6 @@ impl<'arena> NulTermStr<'arena> {
     /// would otherwise have to be length checks.
     ///
     /// ```rust
-    /// # extern crate toolshed;
     /// # use toolshed::Arena;
     /// # fn main() {
     /// let arena = Arena::new();
@@ -452,11 +451,9 @@ mod test {
         assert_eq!(arena.offset.get(), 16);
         assert_eq!(
             allocated,
-            &[
-                b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', 0
-            ]
+            "abcdefghijk\u{0}".as_bytes(),
         );
 
-        assert_eq!(nts.to_string(), "abcdefghijk");
+        assert_eq!(&**nts, "abcdefghijk");
     }
 }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -38,15 +38,6 @@ impl<T: Copy> CopyCell<T> {
         self.value
     }
 
-    /// Returns a mutable reference to the underlying data.
-    ///
-    /// This call borrows `CopyCell` mutably, which gives us a compile time
-    /// memory safety guarantee.
-    #[inline]
-    pub fn get_mut<'a>(&'a mut self) -> &'a mut T {
-        &mut self.value
-    }
-
     /// Sets the contained value.
     #[inline]
     pub fn set(&self, value: T) {

--- a/src/impl_debug.rs
+++ b/src/impl_debug.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug};
-use list::{List, GrowableList, ListBuilder};
-use map::{Map, BloomMap};
-use set::{Set, BloomSet};
+use crate::list::{List, GrowableList, ListBuilder};
+use crate::map::{Map, BloomMap};
+use crate::set::{Set, BloomSet};
 
 impl<'arena, T> Debug for List<'arena, T>
 where
@@ -78,7 +78,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use Arena;
+    use crate::Arena;
 
     #[test]
     fn list_debug() {

--- a/src/impl_partial_eq.rs
+++ b/src/impl_partial_eq.rs
@@ -1,6 +1,6 @@
-use list::List;
-use map::{Map, BloomMap};
-use set::{Set, BloomSet};
+use crate::list::List;
+use crate::map::{Map, BloomMap};
+use crate::set::{Set, BloomSet};
 
 impl<'a, 'b, A, B> PartialEq<List<'b, B>> for List<'a, A>
 where

--- a/src/impl_serialize.rs
+++ b/src/impl_serialize.rs
@@ -1,7 +1,7 @@
 use serde::ser::{Serialize, Serializer};
-use list::List;
-use map::{Map, BloomMap};
-use set::{Set, BloomSet};
+use crate::list::List;
+use crate::map::{Map, BloomMap};
+use crate::set::{Set, BloomSet};
 
 impl<'arena, T> Serialize for List<'arena, T>
 where
@@ -74,7 +74,7 @@ where
 mod test {
     use super::*;
     use serde_json;
-    use Arena;
+    use crate::Arena;
 
     #[test]
     fn list_can_be_serialized() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,6 @@
 //! ## Example
 //!
 //! ```rust
-//!
-//! extern crate toolshed;
-//!
 //! use toolshed::Arena;
 //! use toolshed::map::Map;
 //!
@@ -92,13 +89,11 @@
 
 // Pull in serde if `impl_serialize` is enabled
 #[cfg(feature = "impl_serialize")]
-extern crate serde;
+use serde;
 
 // Pull in serde_json for testing if `impl_serialize` is enabled
 #[cfg(all(test, feature = "impl_serialize"))]
-extern crate serde_json;
-
-extern crate fxhash;
+use serde_json;
 
 mod cell;
 pub mod map;
@@ -112,5 +107,5 @@ mod impl_debug;
 #[cfg(feature = "impl_serialize")]
 mod impl_serialize;
 
-pub use arena::{Arena, Uninitialized, NulTermStr};
-pub use cell::CopyCell;
+pub use self::arena::{Arena, Uninitialized, NulTermStr};
+pub use self::cell::CopyCell;

--- a/src/set.rs
+++ b/src/set.rs
@@ -2,32 +2,25 @@
 
 use std::hash::Hash;
 
-use map::{Map, BloomMap, MapIter};
-use Arena;
+use crate::map::{Map, BloomMap, MapIter};
+use crate::Arena;
 
 /// A set of values. This structure is using a `Map` with value
 /// type set to `()` internally.
 #[derive(Clone, Copy)]
-pub struct Set<'arena, I: 'arena> {
+pub struct Set<'arena, I> {
     map: Map<'arena, I, ()>,
 }
 
-impl<'arena, I> Default for Set<'arena, I>
-where
-    I: 'arena,
-{
+impl<I> Default for Set<'_, I> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'arena, I> Set<'arena, I>
-where
-    I: 'arena,
-{
+impl<'arena, I> Set<'arena, I> {
     /// Creates a new, empty `Set`.
-    #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Set {
             map: Map::new(),
         }
@@ -56,7 +49,7 @@ where
 
 impl<'arena, I> Set<'arena, I>
 where
-    I: 'arena + Eq + Hash + Copy,
+    I: Eq + Hash + Copy,
 {
     /// Inserts a value into the set.
     #[inline]
@@ -80,17 +73,13 @@ where
 /// A set of values with a bloom filter. This structure is
 /// using a `BloomMap` with value type set to `()` internally.
 #[derive(Clone, Copy)]
-pub struct BloomSet<'arena, I: 'arena> {
+pub struct BloomSet<'arena, I> {
     map: BloomMap<'arena, I, ()>,
 }
 
-impl<'arena, I> BloomSet<'arena, I>
-where
-    I: 'arena,
-{
+impl<'arena, I> BloomSet<'arena, I> {
     /// Creates a new, empty `BloomSet`.
-    #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         BloomSet {
             map: BloomMap::new(),
         }
@@ -119,7 +108,7 @@ where
 
 impl<'arena, I> BloomSet<'arena, I>
 where
-    I: 'arena + Eq + Hash + Copy + AsRef<[u8]>,
+    I: Eq + Hash + Copy + AsRef<[u8]>,
 {
     /// Inserts a value into the set.
     #[inline]
@@ -135,11 +124,11 @@ where
 }
 
 /// An iterator over the elements in the set.
-pub struct SetIter<'arena, I: 'arena> {
+pub struct SetIter<'arena, I> {
     inner: MapIter<'arena, I, ()>
 }
 
-impl<'arena, I: 'arena> Iterator for SetIter<'arena, I> {
+impl<'arena, I> Iterator for SetIter<'arena, I> {
     type Item = &'arena I;
 
     #[inline]
@@ -148,10 +137,7 @@ impl<'arena, I: 'arena> Iterator for SetIter<'arena, I> {
     }
 }
 
-impl<'arena, I> IntoIterator for Set<'arena, I>
-where
-    I: 'arena,
-{
+impl<'arena, I> IntoIterator for Set<'arena, I> {
     type Item = &'arena I;
     type IntoIter = SetIter<'arena, I>;
 
@@ -161,10 +147,7 @@ where
     }
 }
 
-impl<'arena, I> IntoIterator for BloomSet<'arena, I>
-where
-    I: 'arena,
-{
+impl<'arena, I> IntoIterator for BloomSet<'arena, I> {
     type Item = &'arena I;
     type IntoIter = SetIter<'arena, I>;
 
@@ -176,7 +159,7 @@ where
 
 impl<'arena, I> From<Set<'arena, I>> for BloomSet<'arena, I>
 where
-    I: 'arena + Eq + Hash + Copy + AsRef<[u8]>,
+    I: Eq + Hash + Copy + AsRef<[u8]>,
 {
     #[inline]
     fn from(set: Set<'arena, I>) -> BloomSet<'arena, I> {
@@ -186,10 +169,7 @@ where
     }
 }
 
-impl<'arena, I> From<BloomSet<'arena, I>> for Set<'arena, I>
-where
-    I: 'arena + Eq + Hash + Copy + AsRef<[u8]>,
-{
+impl<'arena, I> From<BloomSet<'arena, I>> for Set<'arena, I> {
     #[inline]
     fn from(bloom_set: BloomSet<'arena, I>) -> Set<'arena, I> {
         Set {


### PR DESCRIPTION
+ Updated to Rust 2018.
+ Removed `CopyCell::get_mut`. Seems unnecessary given how the crate is being used. If this causes issues for you, please file an issue.
+ `UnsafeList` now uses `Option<NonZeroUsize>` internally instead of `usize`, to make it clearer that zero values are mapping to empty lists.